### PR TITLE
Expose calculateComplexity as an API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,78 @@ Flow is supported via `flow-remove-types` and typescript is supported via `@babe
 
 ## Usage
 
-```javascript
-const codehawk = require('codehawk-cli')
+Analyze a single piece of code:
 
-const output = codehawk.analyzeProject('/path/to/project')
-// Do stuff with output!
+```javascript
+const { addComplexity } = require('codehawk-cli')
+
+const STATIC_SAMPLE = `
+    import lodash from 'lodash';
+
+    const chunkIntoFives = (myArr) => {
+        return _.chunk(myArr, 5);
+    }
+
+    export default chunkIntoFives;
+`
+
+const metrics = addComplexity(STATIC_SAMPLE)
+
+// Example output:
+
+{
+    aggregate: {
+        cyclomatic: 2,
+        cyclomaticDensity: 50,
+        halstead: {
+            bugs: 0.015,
+            difficulty: 4.2,
+            effort: 188.885,
+            length: 13,
+            time: 10.494,
+            vocabulary: 11,
+            volume: 44.973,
+            operands: {
+                distinct: 5,
+                total: 7
+            },
+            operators: {
+                distinct: 6,
+                total: 6
+            },
+            time: 10.494
+        },
+        paramCount: 1,
+        sloc: {
+            logical: 4,
+            physical: 9,
+        },
+    },
+    dependencies: [
+        { line: 2, path: 'lodash', type: 'esm' }
+    ],
+    errors: [],
+    lineEnd: 9,
+    lineStart: 1,
+    maintainability: 144.217,
+    codehawkScore: 92.43914887804003
+}
+
 ```
+
+Analyze an entire directory:
+
+```javascript
+const { analyzeProject } = require('codehawk-cli')
+
+const output = analyzeProject('/path/to/project') // FullyAnalyzedEntity[]
+
+// Output contains a tree structure of your directory,
+// with all supported files containing a 'complexityReport'
+// (see above for example)
+```
+
+When analyzing a project via `analyzeProject`, 2 extra data points are available: `timesDependedOn` and `coverage`.
 
 Also see [an example using Next.js](https://github.com/sgb-io/codehawk-cli-example).
 
@@ -57,7 +123,7 @@ Codehawk gathers various complexity metrics, including:
 
 ## Caveats
 
-- Not optimized for production. The project should be considered experimental and slow.
+- Not intended for production. The project should be considered slow and experimental, but is designed to read your production code!
     - Will not run quickly on large projects, so use caution and common sense when applying it to a workflow or pipeline.
     - Recursively traverses directory trees, so if one activates the process inside a node_modules or C drive directory (unintended usage), you are likely to experience problems.
 - Opinionated: the formula for calculating overall file "scores" is arbitrary and based on original, unpublished research. Users are free to interpret the numbers differently and generate their own scorings.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Flow is supported via `flow-remove-types` and typescript is supported via `@babe
 Analyze a single piece of code:
 
 ```javascript
-const { addComplexity } = require('codehawk-cli')
+const { calculateComplexity } = require('codehawk-cli')
 
 const STATIC_SAMPLE = `
     import lodash from 'lodash';
@@ -38,7 +38,7 @@ const STATIC_SAMPLE = `
     export default chunkIntoFives;
 `
 
-const metrics = addComplexity(STATIC_SAMPLE)
+const metrics = calculateComplexity(STATIC_SAMPLE)
 
 // Example output:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:coverage": "jest --coverage",
     "lint": "eslint src/*.**",
     "lint:fix": "eslint --fix src/*.**",
-    "build": "tsc"
+    "build": "tsc",
+    "build:watch": "tsc --watch"
   },
   "author": "Sam Brown (https://github.com/sgb-io)",
   "license": "MPL-2.0",

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,7 +1,15 @@
 import escomplexReporter from './reporters/escomplex'
-import { CoverageMapping, FileWithContents, CompleteCodehawkComplexityResult } from './types'
+import {
+  CoverageMapping,
+  FileWithContents,
+  CompleteCodehawkComplexityResult
+} from './types'
 
-const analyzeFile = (
+export const addComplexity = (sourceCode: string) => {
+  return escomplexReporter(sourceCode)
+}
+
+export const analyzeFile = (
   dirPath: string,
   file: FileWithContents,
   projectCoverage: CoverageMapping[]
@@ -31,7 +39,7 @@ const analyzeFile = (
   const trimmed = file.rawSource.trim()
 
   try {
-    const complexityReport = escomplexReporter(trimmed)
+    const complexityReport = addComplexity(trimmed)
     if (complexityReport) {
       report = {
         ...complexityReport,
@@ -54,5 +62,3 @@ const analyzeFile = (
 
   return report
 }
-
-export default analyzeFile

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -5,7 +5,7 @@ import {
   CompleteCodehawkComplexityResult
 } from './types'
 
-export const addComplexity = (sourceCode: string) => {
+export const calculateComplexity = (sourceCode: string) => {
   return escomplexReporter(sourceCode)
 }
 
@@ -39,7 +39,7 @@ export const analyzeFile = (
   const trimmed = file.rawSource.trim()
 
   try {
-    const complexityReport = addComplexity(trimmed)
+    const complexityReport = calculateComplexity(trimmed)
     if (complexityReport) {
       report = {
         ...complexityReport,

--- a/src/codehawk.ts
+++ b/src/codehawk.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import slash from 'slash'
 import { getCoverage } from './coverage'
-import { analyzeFile, addComplexity } from './analyze'
+import { analyzeFile, calculateComplexity } from './analyze'
 import { getFileContents, walkSync } from './traverseProject'
 import { getTimesDependedOn, getProjectDeps } from './dependencies'
 import {
@@ -23,7 +23,7 @@ interface Results {
 
 const cwd = slash(process.cwd())
 
-export { addComplexity }
+export { calculateComplexity }
 
 export const analyzeProject = (rawPath: string): Results => {
   const optionsPath = path.resolve(`${rawPath}/codehawk.json`)

--- a/src/codehawk.ts
+++ b/src/codehawk.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import slash from 'slash'
 import { getCoverage } from './coverage'
-import analyzeFile from './analyze'
+import { analyzeFile, addComplexity } from './analyze'
 import { getFileContents, walkSync } from './traverseProject'
 import { getTimesDependedOn, getProjectDeps } from './dependencies'
 import {
@@ -23,7 +23,9 @@ interface Results {
 
 const cwd = slash(process.cwd())
 
-const analyzeProject = (rawPath: string): Results => {
+export { addComplexity }
+
+export const analyzeProject = (rawPath: string): Results => {
   const optionsPath = path.resolve(`${rawPath}/codehawk.json`)
 
   let projectOptionsFile = null
@@ -108,5 +110,3 @@ const analyzeProject = (rawPath: string): Results => {
     results: secondRunResults
   }
 }
-
-export default analyzeProject

--- a/test/codehawk.test.js
+++ b/test/codehawk.test.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const { analyzeProject, addComplexity } = require('../build/codehawk')
+const { analyzeProject, calculateComplexity } = require('../build/codehawk')
 
 const cwd = process.cwd()
 const outputMatchesResult = (projectPath) => {
@@ -23,9 +23,9 @@ const STATIC_SAMPLE = `
 `
 
 describe('codehawk-cli', () => {
-    describe('addComplexity', () => {
+    describe('calculateComplexity', () => {
         it('generates metrics from a sample', () => {
-            const metrics = addComplexity(STATIC_SAMPLE)
+            const metrics = calculateComplexity(STATIC_SAMPLE)
             const expectedMetrics = {
                 aggregate: {
                     cyclomatic: 2,

--- a/test/codehawk.test.js
+++ b/test/codehawk.test.js
@@ -1,40 +1,96 @@
 const fs = require('fs')
-const analyzeProject = require('../build/codehawk').default
+const { analyzeProject, addComplexity } = require('../build/codehawk')
 
-describe('codehawk.analyzeProject', () => {
-    const cwd = process.cwd()
+const cwd = process.cwd()
+const outputMatchesResult = (projectPath) => {
+    const output = analyzeProject(`${cwd}/${projectPath}`)
+    expect(output).toBeTruthy()
 
-    const outputMatchesResult = (projectPath) => {
-        const output = analyzeProject(`${cwd}/${projectPath}`)
-        expect(output).toBeTruthy()
+    const expectedRaw = fs.readFileSync(`${cwd}/${projectPath}/expected.json`)
+    const expected = JSON.parse(expectedRaw)
 
-        const expectedRaw = fs.readFileSync(`${cwd}/${projectPath}/expected.json`)
-        const expected = JSON.parse(expectedRaw)
+    expect(output.results).toEqual(expected.results)
+}
 
-        expect(output.results).toEqual(expected.results)
+const STATIC_SAMPLE = `
+    import lodash from 'lodash';
+
+    const chunkIntoFives = (myArr) => {
+        return _.chunk(myArr, 5);
     }
 
-    it('react-component', () => {
-        outputMatchesResult('samples/react-component')
+    export default chunkIntoFives;
+`
+
+describe('codehawk-cli', () => {
+    describe('addComplexity', () => {
+        it('generates metrics from a sample', () => {
+            const metrics = addComplexity(STATIC_SAMPLE)
+            const expectedMetrics = {
+                aggregate: {
+                    cyclomatic: 2,
+                    cyclomaticDensity: 50,
+                    halstead: {
+                        bugs: 0.015,
+                        difficulty: 4.2,
+                        effort: 188.885,
+                        length: 13,
+                        time: 10.494,
+                        vocabulary: 11,
+                        volume: 44.973,
+                        operands: {
+                            distinct: 5,
+                            total: 7
+                        },
+                        operators: {
+                            distinct: 6,
+                            total: 6
+                        },
+                        time: 10.494
+                    },
+                    paramCount: 1,
+                    sloc: {
+                        logical: 4,
+                        physical: 9,
+                    },
+                },
+                dependencies: [
+                    { line: 2, path: 'lodash', type: 'esm' }
+                ],
+                errors: [],
+                lineEnd: 9,
+                lineStart: 1,
+                maintainability: 144.217,
+                codehawkScore: 92.43914887804003
+            }
+
+            expect(metrics).toEqual(expectedMetrics)
+        })
     })
 
-    it('react-component-flow', () => {
-        outputMatchesResult('samples/react-component-flow')
-    })
+    describe('analyzeProject', () => {
+        it('react-component', () => {
+            outputMatchesResult('samples/react-component')
+        })
 
-    it('simple-class', () => {
-        outputMatchesResult('samples/simple-class')
-    })
+        it('react-component-flow', () => {
+            outputMatchesResult('samples/react-component-flow')
+        })
 
-    it('simple-es6-imports', () => {
-        outputMatchesResult('samples/simple-es6-imports')
-    })
+        it('simple-class', () => {
+            outputMatchesResult('samples/simple-class')
+        })
 
-    it('react-component-typescript', () => {
-        outputMatchesResult('samples/react-component-typescript')
-    })
+        it('simple-es6-imports', () => {
+            outputMatchesResult('samples/simple-es6-imports')
+        })
 
-    it('sweetalert', () => {
-        outputMatchesResult('samples/sweetalert')
+        it('react-component-typescript', () => {
+            outputMatchesResult('samples/react-component-typescript')
+        })
+
+        it('sweetalert', () => {
+            outputMatchesResult('samples/sweetalert')
+        })
     })
 })


### PR DESCRIPTION
- Introduces the `calculateComplexity` name and exposes it to allow single-file static analysis
- Update docs etc
- Unrealated: added a `build:watch` script