### PR TITLE
Use full filepaths in table output, fix the formatting

### DIFF
--- a/src/cli-util.ts
+++ b/src/cli-util.ts
@@ -1,7 +1,7 @@
 import type { FullyAnalyzedFile } from './types'
 
 const colLengths = {
-  filename: 30,
+  filename: 50,
   lines: 10,
   timesUsed: 22,
   maintainability: 34,
@@ -11,7 +11,7 @@ const round = (num: number): number => Math.round(num * 100) / 100
 
 const formatCol = (value: string, limit: number): string => {
   return value.length > limit
-    ? value.slice(limit + 3).padStart(limit, '.')
+    ? value.slice(value.length - (limit - 3)).padStart(limit, '.')
     : value.padEnd(limit, ' ')
 }
 
@@ -32,7 +32,7 @@ const formatComplexityScore = (score: number): string => {
 const generateTableLines = (flatFileResults: FullyAnalyzedFile[]): string => {
   return flatFileResults
     .map((result) => {
-      const { complexityReport, filename, timesDependedOn } = result
+      const { complexityReport, timesDependedOn, fullPath } = result
 
       if (!complexityReport) {
         return ''
@@ -42,7 +42,7 @@ const generateTableLines = (flatFileResults: FullyAnalyzedFile[]): string => {
       const score = formatComplexityScore(codehawkScore)
 
       // Convert output into stdout-friendly, padded columns
-      const filenameCol = formatCol(filename, colLengths.filename)
+      const filenameCol = formatCol(fullPath, colLengths.filename)
       const linesCol = formatCol(lineEnd.toString(), colLengths.lines)
       // Add 1 to the times depended on, assuming that all files are used at least once
       // (Codehawk reports external uses only)
@@ -64,8 +64,8 @@ export const formatResultsAsTable = (
     Codehawk Static Analysis Results
     Top ${flatFileResults.length} file${flatFileResults.length > 1 ? 's' : ''}
 
-    | File                           | # of Lines | Times Used/Depended On | Maintainability (higher is better) |
-    | ------------------------------ | ---------- | ---------------------- | ---------------------------------- |
+    | File                                               | # of Lines | Times Used/Depended On | Maintainability (higher is better) |
+    | -------------------------------------------------- | ---------- | ---------------------- | ---------------------------------- |
     ${generateTableLines(flatFileResults)}
   `
 }

--- a/src/codehawk.ts
+++ b/src/codehawk.ts
@@ -116,7 +116,7 @@ const analyzeProject = (rawPath: string, isCliContext?: boolean): Results => {
   }
 }
 
-export const getResultsAsList = (
+const getResultsAsList = (
   analyzedEntities: FullyAnalyzedEntity[],
   limit?: number
 ): FullyAnalyzedFile[] => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { analyzeProject, getResultsAsList, generateBadge } from './codehawk'
+import { analyzeProject, generateBadge } from './codehawk'
 import { formatResultsAsTable } from './cli-util'
 
 // Sample CLI usage: `codehawk src`
@@ -8,8 +8,7 @@ const scanDir = process.argv.slice(2)[0]
 
 if (scanDir && scanDir !== '') {
   const output = analyzeProject(`${process.cwd()}/${scanDir}`, true)
-  const resultsAsList = getResultsAsList(output.fullResultsTree)
-  const formattedAsTable = resultsAsList.slice(0, 25)
+  const formattedAsTable = output.resultsList.slice(0, 25)
   console.log(formatResultsAsTable(formattedAsTable))
 
   try {

--- a/test/codehawk.test.js
+++ b/test/codehawk.test.js
@@ -1,18 +1,24 @@
 const fs = require('fs')
-const { analyzeProject, calculateComplexity, generateBadge } = require('../build/codehawk')
+const {
+  analyzeProject,
+  calculateComplexity,
+  generateBadge,
+} = require('../build/codehawk')
+const { formatResultsAsTable } = require('../build/cli-util')
+const { JsxEmit } = require('typescript')
 
 const cwd = process.cwd()
 const outputMatchesResult = (projectPath) => {
-    const output = analyzeProject(`${cwd}/${projectPath}`)
-    expect(output).toBeTruthy()
+  const output = analyzeProject(`${cwd}/${projectPath}`)
+  expect(output).toBeTruthy()
 
-    const expectedRaw = fs.readFileSync(`${cwd}/${projectPath}/expected.json`)
-    const expected = JSON.parse(expectedRaw)
+  const expectedRaw = fs.readFileSync(`${cwd}/${projectPath}/expected.json`)
+  const expected = JSON.parse(expectedRaw)
 
-    expect(output.fullResultsTree).toEqual(expected.fullResultsTree)
+  expect(output.fullResultsTree).toEqual(expected.fullResultsTree)
 
-    generateBadge(output.summary)
-    expect('generateBadge did not throw').toBeTruthy()
+  generateBadge(output.summary)
+  expect('generateBadge did not throw').toBeTruthy()
 }
 
 const STATIC_SAMPLE = `
@@ -26,77 +32,118 @@ const STATIC_SAMPLE = `
 `
 
 describe('codehawk-cli', () => {
-    describe('calculateComplexity', () => {
-        it('generates metrics from a static typescript sample', () => {
-            const metrics = calculateComplexity(
-                STATIC_SAMPLE,
-                '.ts',
-                true,
-                false
-            )
-            const expectedMetrics = {
-                aggregate: {
-                    cyclomatic: 2,
-                    cyclomaticDensity: 50,
-                    halstead: {
-                        bugs: 0.015,
-                        difficulty: 4.2,
-                        effort: 188.885,
-                        length: 13,
-                        time: 10.494,
-                        vocabulary: 11,
-                        volume: 44.973,
-                        operands: {
-                            distinct: 5,
-                            total: 7
-                        },
-                        operators: {
-                            distinct: 6,
-                            total: 6
-                        },
-                        time: 10.494
-                    },
-                    paramCount: 1,
-                    sloc: {
-                        logical: 4,
-                        physical: 5,
-                    },
-                },
-                dependencies: [], // TS removes the lodash dep because it's fake i.e. it resolves to undefined
-                errors: [],
-                lineEnd: 5,
-                lineStart: 1,
-                maintainability: 144.217,
-                codehawkScore: 92.43914887804003
-            }
+  describe('calculateComplexity', () => {
+    it('generates metrics from a static typescript sample', () => {
+      const metrics = calculateComplexity(STATIC_SAMPLE, '.ts', true, false)
+      const expectedMetrics = {
+        aggregate: {
+          cyclomatic: 2,
+          cyclomaticDensity: 50,
+          halstead: {
+            bugs: 0.015,
+            difficulty: 4.2,
+            effort: 188.885,
+            length: 13,
+            time: 10.494,
+            vocabulary: 11,
+            volume: 44.973,
+            operands: {
+              distinct: 5,
+              total: 7,
+            },
+            operators: {
+              distinct: 6,
+              total: 6,
+            },
+            time: 10.494,
+          },
+          paramCount: 1,
+          sloc: {
+            logical: 4,
+            physical: 5,
+          },
+        },
+        dependencies: [], // TS removes the lodash dep because it's fake i.e. it resolves to undefined
+        errors: [],
+        lineEnd: 5,
+        lineStart: 1,
+        maintainability: 144.217,
+        codehawkScore: 92.43914887804003,
+      }
 
-            expect(metrics).toEqual(expectedMetrics)
-        })
+      expect(metrics).toEqual(expectedMetrics)
+    })
+  })
+
+  describe('analyzeProject', () => {
+    it('react-component', () => {
+      outputMatchesResult('samples/react-component')
     })
 
-    describe('analyzeProject', () => {
-        it('react-component', () => {
-            outputMatchesResult('samples/react-component')
-        })
-
-        it('react-component-flow', () => {
-            outputMatchesResult('samples/react-component-flow')
-        })
-
-        it('simple-class', () => {
-            outputMatchesResult('samples/simple-class')
-        })
-
-        it('simple-es6-imports', () => {
-            outputMatchesResult('samples/simple-es6-imports')
-        })
-
-        it('react-component-typescript', () => {
-            outputMatchesResult('samples/react-component-typescript')
-        })
-
-        it('sweetalert', () => {
-            outputMatchesResult('samples/sweetalert')
-        })
+    it('react-component-flow', () => {
+      outputMatchesResult('samples/react-component-flow')
     })
+
+    it('simple-class', () => {
+      outputMatchesResult('samples/simple-class')
+    })
+
+    it('simple-es6-imports', () => {
+      outputMatchesResult('samples/simple-es6-imports')
+    })
+
+    it('react-component-typescript', () => {
+      outputMatchesResult('samples/react-component-typescript')
+    })
+
+    it('sweetalert', () => {
+      outputMatchesResult('samples/sweetalert')
+    })
+  })
+
+  describe('CLI output', () => {
+    const logSpy = jest.spyOn(console, 'log')
+
+    // Note: whitespace is important for this test to pass
+    const expectedOutputText =
+`
+    Codehawk Static Analysis Results
+    Top 25 files
+
+    | File                                               | # of Lines | Times Used/Depended On | Maintainability (higher is better) |
+    | -------------------------------------------------- | ---------- | ---------------------- | ---------------------------------- |
+    | /samples/sweetalert/webpack.config.js              | 104        | 1                      | 44.91 (Needs improvement)          |
+    | /samples/sweetalert/src/modules/options/index.ts   | 150        | 2                      | 46.51 (Needs improvement)          |
+    | /samples/sweetalert/src/modules/options/buttons.ts | 150        | 8                      | 47.07 (Needs improvement)          |
+    | /samples/sweetalert/src/modules/event-listeners.ts | 141        | 2                      | 47.3 (Needs improvement)           |
+    | .../sweetalert/src/modules/options/deprecations.ts | 105        | 3                      | 47.38 (Needs improvement)          |
+    | /samples/sweetalert/src/polyfills.js               | 110        | 1                      | 49.61 (Needs improvement)          |
+    | /samples/sweetalert/src/modules/init/buttons.ts    | 81         | 3                      | 52.64 (Could be better)            |
+    | /samples/sweetalert/src/modules/actions.ts         | 67         | 5                      | 53.68 (Could be better)            |
+    | /samples/sweetalert/src/modules/init/content.ts    | 72         | 3                      | 54.05 (Could be better)            |
+    | /samples/sweetalert/src/modules/init/modal.ts      | 65         | 7                      | 54.53 (Could be better)            |
+    | /samples/sweetalert/src/modules/utils.ts           | 61         | 11                     | 55.43 (Could be better)            |
+    | /samples/sweetalert/src/modules/init/icon.ts       | 47         | 3                      | 56.82 (Could be better)            |
+    | /samples/sweetalert/src/modules/state.ts           | 51         | 6                      | 57.14 (Could be better)            |
+    | /samples/sweetalert/src/modules/markup/icons.ts    | 33         | 7                      | 58.89 (Could be better)            |
+    | /samples/sweetalert/src/core.ts                    | 34         | 1                      | 59.8 (Could be better)             |
+    | /samples/sweetalert/src/modules/init/text.ts       | 38         | 3                      | 60.21 OK                           |
+    | /samples/sweetalert/src/modules/init/index.ts      | 30         | 2                      | 60.93 OK                           |
+    | /samples/sweetalert/src/modules/options/content.ts | 27         | 3                      | 62.7 OK                            |
+    | ...ples/sweetalert/src/modules/class-list/index.ts | 28         | 14                     | 88.72 OK                           |
+    | /samples/sweetalert/postcss.config.js              | 10         | 1                      | 91.08 OK                           |
+    | /samples/sweetalert/src/sweetalert.js              | 15         | 1                      | 91.12 OK                           |
+    | /samples/sweetalert/src/modules/markup/index.ts    | 22         | 7                      | 91.25 OK                           |
+    | /samples/sweetalert/src/modules/markup/buttons.ts  | 21         | 7                      | 91.84 OK                           |
+    | /samples/sweetalert/src/modules/init/overlay.ts    | 9          | 3                      | 92.17 OK                           |
+    | /samples/sweetalert/src/modules/markup/modal.ts    | 12         | 7                      | 92.31 OK                           |
+  `
+
+    it('generates the expected table output', () => {
+      const output = analyzeProject(`${cwd}/samples/sweetalert`)
+      const formattedAsTable = output.resultsList.slice(0, 25)
+      console.log(formatResultsAsTable(formattedAsTable))
+      expect(logSpy).toHaveBeenCalledWith(expectedOutputText)
+    })
+  })
 })


### PR DESCRIPTION
Also

- Ddded a test case for the table output + reformatted the codehawk test file using prettier
- Updated the file column length to be 50 instead of 30

Resolves #31 