### PR TITLE
Bump to 7.1.2, remove bad publish steps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ bin
 
 # Types
 src/types/*
+*.svg

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codehawk-cli",
-  "version": "7.1.0",
+  "version": "7.1.2",
   "description": "Static analysis tool for JavaScript projects",
   "scripts": {
     "build:watch": "tsc --watch",
@@ -8,7 +8,6 @@
     "isclean": "git diff --exit-code",
     "lint:fix": "eslint --fix src/*.**",
     "lint": "eslint src/*.**",
-    "prepublishOnly": "yarn build && yarn test",
     "prettier:fix": "prettier --write src",
     "prettier": "prettier --check src",
     "reflect": "node build/index.js src",


### PR DESCRIPTION
These steps in conjunction with "yarn publish" were giving a different result to "npm publish". Using "npm publish" manually for now.