### PR TITLE
Add cliOutputLimit, document minimumThreshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ Top 14 files
 | /src/index.ts                                      | 20         | 1                      | 60.97 OK                           |
 ```
 
+## Options
+
+To customise your analysis, use the following options, placed in a `codehawk.json` file in the root directory.
+
+| Option               | Description                                                                                                                                                                                                                                                                  | Default                                         |
+|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| `badgesDirectory`    | Directory where the two maintainbility badges will be created (when enabled)                                                                                                                                                                                                 | `['/generated']`                                |
+| `enableFlow`         | Enable Flow support                                                                                                                                                                                                                                                          | `false`                                         |
+| `extensions`         | File extensions that should be analyzed. The default is always used, but you can add more extensions. You can use the `exclude[...]` options to exclude specific files.                                                                                                      | `['.js', '.jsx', '.ts', '.tsx']`                |
+| `excludeFilenames`   | Filename matches that should be excluded from static analysis (but still show in the data). The default is always used, but you can add more matches to be excluded. Note that the matching is exact. The exclude list is taken into consideration after the extension list. | `['.d.ts', '.min.js', '.bundle.js']`            |
+| `excludeDirectories` | Directory matches that should be excluded from static analysis (but still show in the data). Relative to the root. E.g. `['/fixtures', '/test']`                                                                                                                             | `['/dist', '/bin', '/build']`                   |
+| `excludeExact`       | Exact file matches that should be excluded from static analysis (but still show in the data). Relative to the root. E.g. `['/src/foo/bar.ts']`                                                                                                                               | `[]`                                            |
+| `skipDirectories`    | Directories that should be excluded completely, i.e. not visible in the resulting data at all. The defaults will always be skipped.                                                                                                                                          | `['/node_modules', '/flow-typed', '/coverage']` |
+| `minimumThreshold`   | Minimum acceptable maintainability score. If a file violates this score, the CLI will exit with code 1 (used to ensure a minimum level of maintainability in CI). It is recommended to set this to at least 30.                                                              | `10`                                            |
+| `cliOutputLimit`     | Number of files to list in the CLI output (from worst scoring to best scoring).                                                                                                                                                                                              | `25`                                            |
+
+
 ## Advanced usage
 
 Analyze an entire directory:
@@ -107,21 +124,6 @@ Each analyzed file in your project ends up with:
 - `dependencies` - a map of this file's dependecies
 - `timesDependedOn` - number of times this file is imported by other files
 - `complexityReport` - various detailed complexity metrics such as halstead metrics and cyclomatic complexity
-
-## Options
-
-To customise your analysis, use the following options, placed in a `codehawk.json` file in the root directory.
-
-| Option               | Description                                                                                                                                                                                                                                                                  | Default                                         |
-|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
-| `badgesDirectory`    | Directory where the two maintainbility badges will be created (when enabled)                                                                                                                                                                                                 | `['/generated']`                                |
-| `enableFlow`         | Enable Flow support                                                                                                                                                                                                                                                          | `false`                                         |
-| `extensions`         | File extensions that should be analyzed. The default is always used, but you can add more extensions. You can use the `exclude[...]` options to exclude specific files.                                                                                                      | `['.js', '.jsx', '.ts', '.tsx']`                |
-| `excludeFilenames`   | Filename matches that should be excluded from static analysis (but still show in the data). The default is always used, but you can add more matches to be excluded. Note that the matching is exact. The exclude list is taken into consideration after the extension list. | `['.d.ts', '.min.js', '.bundle.js']`            |
-| `excludeDirectories` | Directory matches that should be excluded from static analysis (but still show in the data). Relative to the root. E.g. `['/fixtures', '/test']`                                                                                                                             | `['/dist', '/bin', '/build']`                   |
-| `excludeExact`       | Exact file matches that should be excluded from static analysis (but still show in the data). Relative to the root. E.g. `['/src/foo/bar.ts']`                                                                                                                               | `[]`                                            |
-| `skipDirectories`    | Directories that should be excluded completely, i.e. not visible in the resulting data at all. The defaults will always be skipped.                                                                                                                                          | `['/node_modules', '/flow-typed', '/coverage']` |
-
 ## Badges
 
 By default, codehawk-cli generates 2 badges (in `generated/*.svg`) when called via the main CLI interface:

--- a/generated/avg-maintainability.svg
+++ b/generated/avg-maintainability.svg
@@ -1,5 +1,5 @@
-<svg width="167.7" height="20" viewBox="0 0 1677 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="maintainability (avg): 56.28">
-  <title>maintainability (avg): 56.28</title>
+<svg width="167.7" height="20" viewBox="0 0 1677 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="maintainability (avg): 56.25">
+  <title>maintainability (avg): 56.25</title>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -13,8 +13,8 @@
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="1157" fill="#000" opacity="0.25">maintainability (avg)</text>
     <text x="50" y="138" textLength="1157">maintainability (avg)</text>
-    <text x="1312" y="148" textLength="320" fill="#000" opacity="0.25">56.28</text>
-    <text x="1302" y="138" textLength="320">56.28</text>
+    <text x="1312" y="148" textLength="320" fill="#000" opacity="0.25">56.25</text>
+    <text x="1302" y="138" textLength="320">56.25</text>
   </g>
   
 </svg>

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,10 @@ import { hideBin } from 'yargs/helpers'
 const run = (scanDir: string, createBadge: boolean): void => {
   if (scanDir && scanDir !== '') {
     const output = analyzeProject(`${process.cwd()}/${scanDir}`, true)
-    const formattedAsTable = output.resultsList.slice(0, 25)
+    const formattedAsTable = output.resultsList.slice(
+      0,
+      output.options.cliOutputLimit
+    )
     console.log(formatResultsAsTable(formattedAsTable))
 
     if (!createBadge) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -45,6 +45,11 @@ const baseOptions: CodehawkOptions = {
     default: 10,
     replaceDefault: true,
   },
+  cliOutputLimit: {
+    type: 'number',
+    default: 25,
+    replaceDefault: true,
+  },
 }
 
 const injectOptionValues = ({
@@ -72,6 +77,7 @@ const injectOptionValues = ({
       newOptions[optionKey] = val as string[]
       break
     case 'minimumThreshold':
+    case 'cliOutputLimit':
       newOptions[optionKey] = parseInt(val, 10)
       break
     default:

--- a/src/types/codehawk.ts
+++ b/src/types/codehawk.ts
@@ -7,7 +7,7 @@ type SupportedStringArrayKeys =
     | 'extensions'
     | 'skipDirectories'
 type SupportedBooleanOptions = 'enableFlow'
-type SupportedNumberOptions = 'minimumThreshold'
+type SupportedNumberOptions = 'minimumThreshold' | 'cliOutputLimit'
 
 export type AllOptionKeys =
   | SupportedStringArrayKeys


### PR DESCRIPTION
- Adds `cliOutputLimit` as an option which controls how many files are output in the table summary (default 25) (Resolves #90)
- Documents `cliOutputLimit` and also documents `minimumThreshold` which was missing docs before (Resolves #89)